### PR TITLE
Add Linux C-Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# binaries
+fancontroller_linux

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+CPPFLAGS = -DNDEBUG
+CFLAGS = -std=c99 -Wall -pedantic -Wextra -Wshadow -Wconversion
+
+all: fancontroller_linux
+
+fancontroller_linux: fancontroller_linux.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $<
+
+clean:
+	$(RM) fancontroller_linux

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+<!-- Required extensions: mdx_gfm -->
+
 # Acer 5750G Fan Maximiser
-==========================
 
 Max out Acer 5750G Fan Speed.
 
@@ -21,6 +22,7 @@ The magic values, port numbers and read/write sequences were obtained by reverse
 http://community.acer.com/t5/Notebooks-Netbooks/Fan-Control-Problems-With-5750G-And-similar-machines/m-p/199637/highlight/true#M33756
 
 Files and description:
+
 * `acer_5750G_fan_controller.pl`: perl script that does the magic.
 Can be invoked with `perl acer_5750G_fan_controller.pl MAX` or `perl acer_5750G_fan_controller.pl NORMAL`.
 Permission to access /dev/ports is required.
@@ -28,5 +30,7 @@ Permission to access /dev/ports is required.
 This essentially does the same ioctls as FanController.exe. I first wrote this to test that the order in which ports were written to / read from was correct.
 If using Windows, it is higly recommended you use Acer's original app.
 I have included this file just in case somebody might be interested in what driver and what ioctls FanController.exe uses.
+* `fancontroller_linux.c`: A C clone that does the same thing.  
+Compile using `$ make` and run with arguments `-m` or `n` for max / normal settings.
 
 For details about how this project came to be as well as how the values were obtained from FanController.exe and eblib.dll, go to http://neduard.wikidot.com/acer-fancontroller-linux

--- a/fancontroller_linux.c
+++ b/fancontroller_linux.c
@@ -12,13 +12,68 @@
 #define _STRINGIFY(s) #s
 #define STRINGIFY(s) _STRINGIFY(s)
 
+#define MAX 0x77
+#define NORMAL 0x76
+#define IOPORTS "/dev/port"
+
+/**
+ * Sets up IOPORTS interface.
+ *
+ * @return filedescriptor for interface
+ */
 int ec_intro_sequence();
+
+/**
+ * Cleans up IOPORTS.
+ *
+ * @param filedescriptor to use
+ * @return 0 on success, -1 on failure
+ */
 int ec_outro_sequence(int fd);
-int initialize_ioports();
+
+/**
+ * Reads one byte from IOPORTS interface.
+ *
+ * @param filedescriptor to use
+ * @port port / position to read from
+ * @return value read on success, -1 on failure
+ */
 int inb(int fd, int port);
+
+/**
+ * Writes one byte to IOPORTS interface.
+ *
+ * *Might exit program early*.
+ *
+ * @param filedescriptor to use
+ * @param port to write to
+ * @param value to write. Must be positive.
+ * @return 0 on success, -1 on failure
+ */
 int outb(int fd, int port, int value);
-int wait_until_bitmask_is_value(int fd, int bitmask, int value);
+
+/**
+ * Waits for a bitmask to appear
+ *
+ * Loops for some time until the given port on the filedescriptor has value
+ * if for specified bitmask.
+ *
+ * @param filedescriptor to use
+ * @param port to read from
+ * @param bitmask to apply
+ * @param value to check. Must be positive.
+ * @return 0 when bitmask appears, -1 if it doesn't
+ */
+int wait_until_bitmask_is_value(int fd, int port, int bitmask, int value);
+
+/**
+ * Prints usage.
+ *
+ * @param stream to use (eg. stdout/stderr)
+ * @param progname to display (usually argv[0])
+ */
 void print_usage(FILE *stream, char *progname);
+
 
 int main(int argc, char *argv[])
 {
@@ -31,11 +86,11 @@ int main(int argc, char *argv[])
 	switch (argv[1][1]) {
 		case 'm':
 		case 'M':
-			cmd = 0x77;
+			cmd = MAX;
 			break;
 		case 'n':
 		case 'N':
-			cmd = 0x76;
+			cmd = NORMAL;
 			break;
 		case 'h':
 			print_usage(stdout, argv[0]);
@@ -45,72 +100,67 @@ int main(int argc, char *argv[])
 			exit(1);
 	}
 
-	assert(cmd != 0);
+	assert(cmd == MAX || cmd == NORMAL);
 
 	int fd = 0;
 	if ((fd = ec_intro_sequence()) < 0) {
-		fprintf(stderr, ERRPREF "Unable to perform intro sequence."
+		fprintf(stderr, ERRPREF "Unable to perform intro sequence. "
 				"Cleaning up\n");
-		ec_outro_sequence(fd);
+		if (fd >= 0) ec_outro_sequence(fd);
 		exit(1);
 	}
 
-	if (wait_until_bitmask_is_value(fd, 0x02, 0x00) != 0) {
-		fprintf(stderr, ERRPREF "Error waiting for magic value."
+	if (wait_until_bitmask_is_value(fd, 0x6C, 0x02, 0x00) != 0) {
+		fprintf(stderr, ERRPREF "Error waiting for magic value. "
 				"Cleaning up\n");
-		ec_outro_sequence(fd);
+		if (fd >= 0) ec_outro_sequence(fd);
 		exit(1);
 	}
 
 	if (outb(fd, 0x68, cmd) != 0) {
 		fprintf(stderr, ERRPREF "Unable to write magic command %x\n",
 				cmd);
-		ec_outro_sequence(fd);
+		if (fd >= 0) ec_outro_sequence(fd);
 		exit (1);
 	}
 
 	ec_outro_sequence(fd);
 }
 
-int initialize_ioports()
+int ec_intro_sequence()
 {
-	int fd = open("/dev/port", O_RDWR);
+	int fd = open(IOPORTS, O_RDWR);
 	if (fd < 0) {
 		perror("open()");
 	}
-	//TODO binmode?
-	return fd;
-}
 
-int ec_intro_sequence()
-{
-	int fd = initialize_ioports();
-	if (wait_until_bitmask_is_value(fd, 0x80, 0x00) != 0) {
+	if (wait_until_bitmask_is_value(fd, 0x6C, 0x80, 0x00) != 0) {
+		return -1;
+	}
+	if (inb(fd, 0x68) == -1) return -1;
+
+	if (wait_until_bitmask_is_value(fd, 0x6C, 0x02, 0x00) != 0) {
 		return -1;
 	}
 
-	inb(fd, 0x68);
-
-	if (wait_until_bitmask_is_value(fd, 0x02, 0x00) != 0) {
-		return -1;
-	}
-
-	outb(fd, 0x6C, 0x59);
+	if (outb(fd, 0x6C, 0x59) == -1) return -1;
 	return fd;
 }
 
-int wait_until_bitmask_is_value(int fd, int bitmask, int value)
+int ec_outro_sequence(int fd)
 {
-	for (int i = 0; i < 10000; i++) {
-		if ((inb(fd, 0x6C) & bitmask) == value) {
-			return 0;
-		}
-		sleep(0);
-		//TODO: sleep(0.01). It actually doesn't sleep. EXPR must be
-		//      an integer expression...
+	if (inb(fd, 0x68) < 0) return -1;
+	if (wait_until_bitmask_is_value(fd, 0x6C, 0x02, 0x00) != 0) {
+		return -1;
 	}
-	fprintf(stderr, ERRPREF "Timeout waiting for mask %x\n", bitmask);
-	return -1;
+	if (outb(fd, 0x6C, 0xFF) < 0) return -1;
+
+	if (close(fd) != 0) {
+		perror("close()");
+		return -1;
+	}
+
+	return 0;
 }
 
 int inb(int fd, int port)
@@ -119,16 +169,19 @@ int inb(int fd, int port)
 		perror("lseek()");
 		return -1;
 	}
+
 	char buf;
 	if (read(fd, &buf, 1) != 1) {
 		perror("read()");
 		return -1;
 	}
+
 	return buf;
 }
 
 int outb(int fd, int port, int value)
 {
+	assert(value > 0);
 	assert(!(value > 0xff));
 
 	if (lseek(fd, port, SEEK_SET) < 0) {
@@ -136,26 +189,28 @@ int outb(int fd, int port, int value)
 		fprintf(stderr, ERRPREF "Fatal Error! Terminating\n");
 		exit(1);
 	}
+
 	if (write(fd, &value, 1) != 1) {
 		perror("write()");
 		return -1;
 	}
+
 	return 0;
 }
 
-int ec_outro_sequence(int fd)
+int wait_until_bitmask_is_value(int fd, int port, int bitmask, int value)
 {
-	inb(fd, 0x68);
-	if (wait_until_bitmask_is_value(fd, 0x02, 0x00) != 0) {
-		return -1;
-	}
-	outb(fd, 0x6C, 0xFF);
-	if (close(fd) != 0) {
-		perror("close()");
-		return -1;
-	}
+	assert(value > 0);
 
-	return 0;
+	for (int i = 0; i < 10000; i++) {
+		if ((inb(fd, port) & bitmask) == value) {
+			return 0;
+		}
+		sleep(0);
+	}
+	fprintf(stderr, ERRPREF "Timeout waiting for mask %x with value %x on port %x\n",
+			bitmask, port);
+	return -1;
 }
 
 void print_usage(FILE *stream, char *progname)

--- a/fancontroller_linux.c
+++ b/fancontroller_linux.c
@@ -206,10 +206,11 @@ int wait_until_bitmask_is_value(int fd, int port, int bitmask, int value)
 		if ((inb(fd, port) & bitmask) == value) {
 			return 0;
 		}
+		//TODO: Investigate. Is this needed?
 		sleep(0);
 	}
 	fprintf(stderr, ERRPREF "Timeout waiting for mask %x with value %x on port %x\n",
-			bitmask, port);
+			bitmask, value, port);
 	return -1;
 }
 

--- a/fancontroller_linux.c
+++ b/fancontroller_linux.c
@@ -22,7 +22,6 @@ void print_usage(FILE *stream, char *progname);
 
 int main(int argc, char *argv[])
 {
-	assert(0);
 	if (argc < 2) {
 		fprintf(stderr, ERRPREF "No arguments supplied (-h for usage)\n");
 		exit(1);

--- a/fancontroller_linux.c
+++ b/fancontroller_linux.c
@@ -1,0 +1,169 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#define PROGNAME fc
+#define ERRPREF "[" STRINGIFY(PROGNAME) "]: "
+#define _STRINGIFY(s) #s
+#define STRINGIFY(s) _STRINGIFY(s)
+
+int ec_intro_sequence();
+int ec_outro_sequence(int fd);
+int initialize_ioports();
+int inb(int fd, int port);
+int outb(int fd, int port, int value);
+int wait_until_bitmask_is_value(int fd, int bitmask, int value);
+void print_usage(FILE *stream, char *progname);
+
+int main(int argc, char *argv[])
+{
+	assert(0);
+	if (argc < 2) {
+		fprintf(stderr, ERRPREF "No arguments supplied (-h for usage)\n");
+		exit(1);
+	}
+
+	int cmd = 0;
+	switch (argv[1][1]) {
+		case 'm':
+		case 'M':
+			cmd = 0x77;
+			break;
+		case 'n':
+		case 'N':
+			cmd = 0x76;
+			break;
+		case 'h':
+			print_usage(stdout, argv[0]);
+			exit(1);
+		default:
+			fprintf(stderr, ERRPREF "Invalid arguments!\n");
+			exit(1);
+	}
+
+	assert(cmd != 0);
+
+	int fd = 0;
+	if ((fd = ec_intro_sequence()) < 0) {
+		fprintf(stderr, ERRPREF "Unable to perform intro sequence."
+				"Cleaning up\n");
+		ec_outro_sequence(fd);
+		exit(1);
+	}
+
+	if (wait_until_bitmask_is_value(fd, 0x02, 0x00) != 0) {
+		fprintf(stderr, ERRPREF "Error waiting for magic value."
+				"Cleaning up\n");
+		ec_outro_sequence(fd);
+		exit(1);
+	}
+
+	if (outb(fd, 0x68, cmd) != 0) {
+		fprintf(stderr, ERRPREF "Unable to write magic command %x\n",
+				cmd);
+		ec_outro_sequence(fd);
+		exit (1);
+	}
+
+	ec_outro_sequence(fd);
+}
+
+int initialize_ioports()
+{
+	int fd = open("/dev/port", O_RDWR);
+	if (fd < 0) {
+		perror("open()");
+	}
+	//TODO binmode?
+	return fd;
+}
+
+int ec_intro_sequence()
+{
+	int fd = initialize_ioports();
+	if (wait_until_bitmask_is_value(fd, 0x80, 0x00) != 0) {
+		return -1;
+	}
+
+	inb(fd, 0x68);
+
+	if (wait_until_bitmask_is_value(fd, 0x02, 0x00) != 0) {
+		return -1;
+	}
+
+	outb(fd, 0x6C, 0x59);
+	return fd;
+}
+
+int wait_until_bitmask_is_value(int fd, int bitmask, int value)
+{
+	for (int i = 0; i < 10000; i++) {
+		if ((inb(fd, 0x6C) & bitmask) == value) {
+			return 0;
+		}
+		sleep(0);
+		//TODO: sleep(0.01). It actually doesn't sleep. EXPR must be
+		//      an integer expression...
+	}
+	fprintf(stderr, ERRPREF "Timeout waiting for mask %x\n", bitmask);
+	return -1;
+}
+
+int inb(int fd, int port)
+{
+	if (lseek(fd, port, SEEK_SET) == -1) {
+		perror("lseek()");
+		return -1;
+	}
+	char buf;
+	if (read(fd, &buf, 1) != 1) {
+		perror("read()");
+		return -1;
+	}
+	return buf;
+}
+
+int outb(int fd, int port, int value)
+{
+	assert(!(value > 0xff));
+
+	if (lseek(fd, port, SEEK_SET) < 0) {
+		perror("lseek()");
+		fprintf(stderr, ERRPREF "Fatal Error! Terminating\n");
+		exit(1);
+	}
+	if (write(fd, &value, 1) != 1) {
+		perror("write()");
+		return -1;
+	}
+	return 0;
+}
+
+int ec_outro_sequence(int fd)
+{
+	inb(fd, 0x68);
+	if (wait_until_bitmask_is_value(fd, 0x02, 0x00) != 0) {
+		return -1;
+	}
+	outb(fd, 0x6C, 0xFF);
+	if (close(fd) != 0) {
+		perror("close()");
+		return -1;
+	}
+
+	return 0;
+}
+
+void print_usage(FILE *stream, char *progname)
+{
+	fprintf(stream, "Usage: %s [options]\n"
+			"Options:\n"
+			" -m\tSet fan to max setting\n"
+			" -n\tSet fan to normal setting\n"
+			" -h\tPrint this help message\n", progname);
+}


### PR DESCRIPTION
Hi,

due to request and me needing something todo this evening I re-implemented the Perl-Script in C for Linux. The code is almost the same and roughly follows the same structure (though not always. eg `IOPORTS` is not the fd to write to but a macro that gets expanded to `"/dev/port").

It works for me really well. I thought about coming back to my project of building a simple GUI that works on Linux/Windows (and doesn't depend on Perl) but I've currently simply no Windows to test on etc. We'll see.
